### PR TITLE
fixes & minor enhancements for core.logic 0.8.0-beta3 & 0.8.0-beta4-SNAPSHOT

### DIFF
--- a/clojure-tapl/tapl/project.clj
+++ b/clojure-tapl/tapl/project.clj
@@ -2,6 +2,6 @@
   :description "TAPL in core.logic"
   :url "https://github.com/namin/TAPL-in-miniKanren-cKanren-core.logic"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/core.logic "0.8.0-beta3-SNAPSHOT"]
+                 [org.clojure/core.logic "0.8.0-beta4-SNAPSHOT"]
                  [org.clojure/core.match "0.2.0-alpha11"]]
   :dev-dependencies [[lein-swank "1.4.3"]])

--- a/clojure-tapl/tapl/test/tapl/test/core.clj
+++ b/clojure-tapl/tapl/test/tapl/test/core.clj
@@ -18,13 +18,13 @@
   )
 
 (deftest test-T
-  (is (= (run* [q] (T :true)) '(_.0)))
-  (is (= (run* [q] (T :false)) '(_.0)))
-  (is (= (run* [q] (T :zero)) '(_.0)))
-  (is (= (run* [q] (T [:succ [:succ [:pred :zero]]])) '(_.0)))
-  (is (= (run* [q] (T [:succ [:succ [:pred :false]]])) '(_.0)))
+  (is (= (run* [q] (T :true)) '(_0)))
+  (is (= (run* [q] (T :false)) '(_0)))
+  (is (= (run* [q] (T :zero)) '(_0)))
+  (is (= (run* [q] (T [:succ [:succ [:pred :zero]]])) '(_0)))
+  (is (= (run* [q] (T [:succ [:succ [:pred :false]]])) '(_0)))
   (is (= (run* [q] (T [:succ [:succ [:pred :foo]]])) '()))
-  (is (= (run* [q] (T [:if :false [:succ :zero] [:pred [:succ :zero]]])) '(_.0)))
+  (is (= (run* [q] (T [:if :false [:succ :zero] [:pred [:succ :zero]]])) '(_0)))
   (is (= (run* [q] (T [:if :false [:succ :foo] [:pred [:succ :zero]]])) '()))
   (is (= (run 100 [q] (T q)))
       '(:true
@@ -133,22 +133,22 @@
   (is (= (run 3 [q] (NV q)) '(:zero [:succ :zero] [:succ [:succ :zero]]))))
 
 (deftest test-E
-  (is (= (run* [q] (E [:if :true :false :true] :false)) '(_.0)))
-  (is (= (run* [q] (E [:if :false :false :true] :true)) '(_.0)))
+  (is (= (run* [q] (E [:if :true :false :true] :false)) '(_0)))
+  (is (= (run* [q] (E [:if :false :false :true] :true)) '(_0)))
   (is (= (run* [q] (E [:if [:if :false :true :false] :false :true] q))
          '([:if :false :false :true])))
   (is (= (run* [q] (E [:if q :false :true] :false)) '(:true)))
   (is (= (run* [q] (E q :zero))
-         '([:if :true :zero _.0]
-           [:if :false _.0 :zero]
+         '([:if :true :zero _0]
+           [:if :false _0 :zero]
            [:pred :zero]
            [:pred [:succ :zero]])))
   (is (= (run* [q] (E :zero q)) '()))
   (is (= (run* [q] (fresh (t1 t2 t3) (== [:if t1 t2 t3] q) (E q :zero)))
-         '([:if :true :zero _.0] [:if :false _.0 :zero]))))
+         '([:if :true :zero _0] [:if :false _0 :zero]))))
 
 (deftest test-TC
-  (is (= (run* [q] (TC :true :Bool)) '(_.0)))
+  (is (= (run* [q] (TC :true :Bool)) '(_0)))
   (is (= (run* [q] (TC [:iszero q] :Nat)) '()))
   (is (= (run* [q] (TC [:succ q] :Bool)) '()))
   (is (= (run* [q] (TC [:if :false :zero :true] q)) '())))

--- a/clojure-tapl/tapl/test/tapl/test/quines.clj
+++ b/clojure-tapl/tapl/test/tapl/test/quines.clj
@@ -6,14 +6,14 @@
   (:use [clojure.test]))
 
 (deftest test-symbolo
-  (is (= (run* [q] (symbolo q)) '((_.0 :- clojure.core/symbol?))))
+  (is (= (run* [q] (symbolo q)) '((_0 :- clojure.core/symbol?))))
   (is (= (run* [q] (symbolo q) (== 'foo q)) '(foo)))
   (is (= (run* [q] (symbolo q) (== 5 q)) '()))
   (is (= (run* [q] (symbolo q) (== '(hello there) q)) '())))
 
 (deftest test-not-in-envo
-  (is (= (run* [q] (not-in-envo q '())) '(_.0)))
-  (is (= (run* [q] (not-in-envo 'x '([y v]))) '(_.0)))
+  (is (= (run* [q] (not-in-envo q '())) '(_0)))
+  (is (= (run* [q] (not-in-envo 'x '([y v]))) '(_0)))
   (is (= (run* [q] (not-in-envo 'x '([x v]))) '()))
   (is (= (run* [q] (not-in-envo 'x '([y v] [x v]))) '())))
 
@@ -29,9 +29,8 @@
   (is (= (run* [q] (eval-expo '((fn [x] x) (quote v)) '() q)) '(v))))
 
 (deftest test-quine
-  (is (= (map first (run 1 [q] (eval-expo q '() q)))
-         '(((fn [_.0] (list _.0 (list 'quote _.0)))
-            '(fn [_.0] (list _.0 (list 'quote _.0))))))))
+  (let [p (first (first (run 1 [q] (eval-expo q '() q))))]
+    (is (= p (eval p)))))
 
 (deftest test-twine
   (is (= (map first (run 1 [q] (fresh [x y]
@@ -39,7 +38,7 @@
                                       (eval-expo x '() y)
                                       (eval-expo y '() x)
                                       (== [x y] q))))
-         '(['((fn [_.0] (list 'quote (list _.0 (list 'quote _.0))))
-              '(fn [_.0] (list 'quote (list _.0 (list 'quote _.0)))))
-            ((fn [_.0] (list 'quote (list _.0 (list 'quote _.0))))
-             '(fn [_.0] (list 'quote (list _.0 (list 'quote _.0)))))]))))
+         '(['((fn [_0] (list 'quote (list _0 (list 'quote _0))))
+              '(fn [_0] (list 'quote (list _0 (list 'quote _0)))))
+            ((fn [_0] (list 'quote (list _0 (list 'quote _0))))
+             '(fn [_0] (list 'quote (list _0 (list 'quote _0)))))]))))


### PR DESCRIPTION
core.logic reifies fresh vars as `_.N`, this is unfortunate since this is not a valid symbol in actual Clojure source. This has been corrected in the latest core.logic betas. fresh vars are now reified as `_N`. This means we can use eval on the Clojure source generated from the quines. I updated one of the quine tests to reflect this.
